### PR TITLE
Add support for alternative namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,24 +27,38 @@ console.log(report);
 
 The `CvrParser` is named like that since it parses information fetched from the Danish national registry [cvr.dk](cvr.dk).
 
-## Danish annual report taxonomy
+### Things to watch out for in the annual reports
+
+The code contains some comments for specific cases that have been discovered along the way. Some of the more interesting ones:
+
+- Some companies report revenue while others report "gross profit". It is unclear what the difference is.
+- Some companies report EBITDA in their PDF reports, but there is no EBITDA field in the taxonomy. As such, EBITDA is a calculated field in the mapped reports.
+
+## XBRL spec notes
+
+Usually, the xbrl instance root element is `<xbrli:xbrl>`.
+The standard also mentions this here: https://specifications.xbrl.org/xbrl-essentials.html
+
+However, in the wild, other namespaces (or no namespaces) have been observed (like `<xbrl>`), which may or may not be valid.
+
+In order to make the output more consistent, there are two options:
+1. Completely ignore the namespace prefix for all XML fields. This is not a good option because other namespaces are lost as well, and it could *potentially* (although unlikely) lead to name clashes of fields when parsed.
+2. Recursively "fix" non-standard namespaces so they are the same.
+
+This library uses the second choice, such that parsed XBRL documents use `xbrli:` as namespace prefix for XBRL-specific fields.
+
+### Danish annual report specifics
 
 The taxonomies for Danish annual reports is documented [here](https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-aktuelle) (in Danish).
 
-**Note**: IFRS is not supported
+For this taxonomy, namespace renaming also happens for some annual reports, and this library tries to correct it.
 
-**Note**: In the wild, we have encountered non-conforming namespaces. These are not supported either.
+Some other notes:
+
+**Note**: IFRS is not supported
 
 **Note**: The field mapping is incomplete.
 
 The mapping is done on a best-effort basis and will most definitely not be correct in all cases.
 
 In other words: Use with caution :D
-
-
-### Things to watch out for
-
-The code contains a some comments for specific cases that have been discovered along the way. Some of the more interesting ones:
-
-- Some companies report revenue while others report "gross profit". It is unclear what the difference is.
-- Some companies report EBITDA in their PDF reports, but there is no EBITDA field in the taxonomy. As such, EBITDA is a calculated field in the mapped reports.

--- a/__tests__/__fixtures__/report1.xml
+++ b/__tests__/__fixtures__/report1.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?><!-- Version: 1.1.1030.0 --><!-- Document created: 12-05-2021 09:24:24 --><!-- Created by:  XBRL Wizard, EasyX --><xbrli:xbrl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:link="http://www.xbrl.org/2003/linkbase" xmlns:xbrldi="http://xbrl.org/2006/xbrldi" xmlns:xbrli="http://www.xbrl.org/2003/instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:iso4217="http://www.xbrl.org/2003/iso4217" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entry="http://xbrl.dcca.dk/entryBalanceSheetAccountFormIncomeStatementByNature" xmlns:gsd="http://xbrl.dcca.dk/gsd" xmlns:tax="http://xbrl.dcca.dk/tax" xmlns:tch="http://xbrl.dcca.dk/tch" xmlns:gen="http://xbrl.org/2008/generic" xmlns:ref="http://www.xbrl.org/2006/ref" xmlns:xbrldt="http://xbrl.org/2005/xbrldt" xmlns:nonnum="http://www.xbrl.org/dtr/type/non-numeric" xmlns:variable="http://xbrl.org/2008/variable" xmlns:eogs="http://xbrl.dcca.dk/eogs" xmlns:xl="http://www.xbrl.org/2003/XLink" xmlns:dst="http://xbrl.dcca.dk/dst" xmlns:arr="http://xbrl.dcca.dk/arr" xmlns:valm="http://xbrl.org/2010/message/validation" xmlns:num="http://www.xbrl.org/dtr/type/numeric" xmlns:msg="http://xbrl.org/2010/message" xmlns:fsa="http://xbrl.dcca.dk/fsa" xmlns:cmn="http://xbrl.dcca.dk/cmn" xmlns:label="http://xbrl.org/2008/label" xmlns:mrv="http://xbrl.dcca.dk/mrv" xmlns:esg="http://xbrl.dcca.dk/esg" xmlns:sob="http://xbrl.dcca.dk/sob" xsi:schemaLocation="http://xbrl.org/2006/xbrldi http://www.xbrl.org/2006/xbrldi-2006.xsd">
+<?xml version="1.0" encoding="UTF-8"?><!-- Version: 1.1.1030.0 --><!-- Document created: 12-05-2021 09:24:24 --><!-- Created by:  XBRL Wizard, EasyX -->
+<xbrli:xbrl xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:link="http://www.xbrl.org/2003/linkbase" xmlns:xbrldi="http://xbrl.org/2006/xbrldi" xmlns:xbrli="http://www.xbrl.org/2003/instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:iso4217="http://www.xbrl.org/2003/iso4217" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:entry="http://xbrl.dcca.dk/entryBalanceSheetAccountFormIncomeStatementByNature" xmlns:gsd="http://xbrl.dcca.dk/gsd" xmlns:tax="http://xbrl.dcca.dk/tax" xmlns:tch="http://xbrl.dcca.dk/tch" xmlns:gen="http://xbrl.org/2008/generic" xmlns:ref="http://www.xbrl.org/2006/ref" xmlns:xbrldt="http://xbrl.org/2005/xbrldt" xmlns:nonnum="http://www.xbrl.org/dtr/type/non-numeric" xmlns:variable="http://xbrl.org/2008/variable" xmlns:eogs="http://xbrl.dcca.dk/eogs" xmlns:xl="http://www.xbrl.org/2003/XLink" xmlns:dst="http://xbrl.dcca.dk/dst" xmlns:arr="http://xbrl.dcca.dk/arr" xmlns:valm="http://xbrl.org/2010/message/validation" xmlns:num="http://www.xbrl.org/dtr/type/numeric" xmlns:msg="http://xbrl.org/2010/message" xmlns:fsa="http://xbrl.dcca.dk/fsa" xmlns:cmn="http://xbrl.dcca.dk/cmn" xmlns:label="http://xbrl.org/2008/label" xmlns:mrv="http://xbrl.dcca.dk/mrv" xmlns:esg="http://xbrl.dcca.dk/esg" xmlns:sob="http://xbrl.dcca.dk/sob" xsi:schemaLocation="http://xbrl.org/2006/xbrldi http://www.xbrl.org/2006/xbrldi-2006.xsd">
   <link:schemaRef xlink:type="simple" xlink:href="http://archprod.service.eogs.dk/taxonomy/20201001/entryDanishGAAPBalanceSheetAccountFormIncomeStatementByNatureIncludingManagementsReviewStatisticsAndTax20201001.xsd"/>
   <xbrli:context id="ctx1">
     <xbrli:entity>
@@ -868,17 +869,6 @@
   <mrv:ValueOfKeyFigureOrFinancialRatio contextRef="ctx34" unitRef="pure" decimals="2">0.15</mrv:ValueOfKeyFigureOrFinancialRatio>
   <mrv:NameOfKeyFigureOrFinancialRatio contextRef="ctx35" xml:lang="da">Soliditetsgrad efter kapitaltilførelse gennemført i maj 2018</mrv:NameOfKeyFigureOrFinancialRatio>
   <mrv:ValueOfKeyFigureOrFinancialRatio contextRef="ctx35" unitRef="pure" decimals="1">0</mrv:ValueOfKeyFigureOrFinancialRatio>
-  <cmn:NameAndSurnameOfMemberOfExecutiveBoard contextRef="ctx36" xml:lang="da">Henrik Bodskov</cmn:NameAndSurnameOfMemberOfExecutiveBoard>
-  <cmn:TitleOfMemberOfExecutiveBoard contextRef="ctx36" xml:lang="da">Adm. direktør</cmn:TitleOfMemberOfExecutiveBoard>
-  <cmn:NameAndSurnameOfMemberOfExecutiveBoard contextRef="ctx37" xml:lang="da">Frank Bøje Andersen</cmn:NameAndSurnameOfMemberOfExecutiveBoard>
-  <cmn:NameAndSurnameOfMemberOfExecutiveBoard contextRef="ctx38" xml:lang="da">Liselotte Tornøe Bøje</cmn:NameAndSurnameOfMemberOfExecutiveBoard>
-  <cmn:NameAndSurnameOfMemberOfExecutiveBoard contextRef="ctx39" xml:lang="da">Jesper Braum Nielsen</cmn:NameAndSurnameOfMemberOfExecutiveBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ctx40" xml:lang="da">Henrik Tang Hedegaard</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:TitleOfMemberOfSupervisoryBoard contextRef="ctx40" xml:lang="da">Formand</cmn:TitleOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ctx41" xml:lang="da">Helle Valentin</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ctx42" xml:lang="da">Henrik Frøkjær-Jensen</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ctx43" xml:lang="da">Kim Frederiksen</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ctx44" xml:lang="da">Flemming Madsen</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
   <fsa:Revenue contextRef="ctx45" unitRef="vDKK" decimals="-3">5030438000</fsa:Revenue>
   <fsa:OtherOperatingIncome contextRef="ctx45" unitRef="vDKK" decimals="-3">12921000</fsa:OtherOperatingIncome>
   <fsa:ExternalExpenses contextRef="ctx45" unitRef="vDKK" decimals="-3">3088013000</fsa:ExternalExpenses>
@@ -938,11 +928,8 @@
   <gsd:AddressOfAuditorDistrictName contextRef="ctx50" xml:lang="da">Hellerup</gsd:AddressOfAuditorDistrictName>
   <cmn:NameOfAuditFirm contextRef="ctx50" xml:lang="da">PricewaterhouseCoopers Statsautoriseret Revisionspartnerselskab</cmn:NameOfAuditFirm>
   <cmn:IdentificationNumberCvrOfAuditFirm contextRef="ctx50">33771231</cmn:IdentificationNumberCvrOfAuditFirm>
-  <cmn:NameAndSurnameOfAuditor contextRef="ctx50" xml:lang="da">Brian Christiansen</cmn:NameAndSurnameOfAuditor>
   <cmn:DescriptionOfAuditor contextRef="ctx50" xml:lang="da">statsautoriseret revisor</cmn:DescriptionOfAuditor>
   <cmn:IdentificationNumberOfAuditor contextRef="ctx50">mne23371</cmn:IdentificationNumberOfAuditor>
-  <cmn:NameAndSurnameOfAuditor contextRef="ctx51" xml:lang="da">Dan Bjerregaard</cmn:NameAndSurnameOfAuditor>
-  <cmn:DescriptionOfAuditor contextRef="ctx51" xml:lang="da">statsautoriseret revisor</cmn:DescriptionOfAuditor>
   <cmn:IdentificationNumberOfAuditor contextRef="ctx51">mne33701</cmn:IdentificationNumberOfAuditor>
   <cmn:IdentificationNumberCvrOfAuditFirm contextRef="ctx51">33771231</cmn:IdentificationNumberCvrOfAuditFirm>
   <cmn:NameOfAuditFirm contextRef="ctx51" xml:lang="da">PricewaterhouseCoopers Statsautoriseret Revisionspartnerselskab</cmn:NameOfAuditFirm>

--- a/__tests__/__fixtures__/report2.xml
+++ b/__tests__/__fixtures__/report2.xml
@@ -342,33 +342,9 @@
   <xbrli:unit id="Share">
     <xbrli:measure>xbrli:shares</xbrli:measure>
   </xbrli:unit>
-  <arr:AddresseeOfAuditorsReportOnExtendedReviewOfFinancialStatements contextRef="ID_0" xml:lang="da">Til kapitalejerne i Officeguru A/S
- </arr:AddresseeOfAuditorsReportOnExtendedReviewOfFinancialStatements>
-  <arr:DescriptionOfQualificationsOfFinancialStatementsExtendedReview contextRef="ID_0" xml:lang="da">Grundlag for konklusion
- </arr:DescriptionOfQualificationsOfFinancialStatementsExtendedReview>
-  <arr:InformationOnSignatureOfAuditors contextRef="ID_0" xml:lang="da">
-</arr:InformationOnSignatureOfAuditors>
-  <arr:OpinionOnFinancialStatementsExtendedReview contextRef="ID_0" xml:lang="da">Konklusion
-</arr:OpinionOnFinancialStatementsExtendedReview>
   <arr:SignatureOfAuditorsDate contextRef="ID_0" xml:lang="da">2021-12-10</arr:SignatureOfAuditorsDate>
-  <arr:SignatureOfAuditorsPlace contextRef="ID_0" xml:lang="da">København</arr:SignatureOfAuditorsPlace>
-  <arr:StatementOfAuditorsResponsibilityExtendedReview contextRef="ID_0" xml:lang="da">Revisors ansvar for den udvidede gennemgang af årsregnskabet
- </arr:StatementOfAuditorsResponsibilityExtendedReview>
-  <arr:StatementOfExecutiveAndSupervisoryBoardsResponsibilityForFinancialStatementsExtendedReview contextRef="ID_0" xml:lang="da">Ledelsens ansvar for årsregnskabet
- </arr:StatementOfExecutiveAndSupervisoryBoardsResponsibilityForFinancialStatementsExtendedReview>
   <cmn:IdentificationNumberCvrOfAuditFirm contextRef="ID_1" xml:lang="da">39463113</cmn:IdentificationNumberCvrOfAuditFirm>
   <cmn:IdentificationNumberOfAuditor contextRef="ID_1" xml:lang="da">mne35842</cmn:IdentificationNumberOfAuditor>
-  <cmn:NameAndSurnameOfAuditor contextRef="ID_1" xml:lang="da">Christian Dohn</cmn:NameAndSurnameOfAuditor>
-  <cmn:NameAndSurnameOfMemberOfExecutiveBoard contextRef="ID_2" xml:lang="da">Daniel Nordberg Wilk</cmn:NameAndSurnameOfMemberOfExecutiveBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ID_3" xml:lang="da">Anders Colding Friis</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ID_4" xml:lang="da">Jens Grønlund</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ID_5" xml:lang="da">Jannik Kruse Petersen</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ID_6" xml:lang="da">Daniel Nordberg Wilk</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ID_7" xml:lang="da">Christian Frørup</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameAndSurnameOfMemberOfSupervisoryBoard contextRef="ID_8" xml:lang="da">Jørgen Wilk</cmn:NameAndSurnameOfMemberOfSupervisoryBoard>
-  <cmn:NameOfAuditFirm contextRef="ID_1" xml:lang="da">KRESTON CM</cmn:NameOfAuditFirm>
-  <cmn:TitleOfMemberOfSupervisoryBoard contextRef="ID_3" xml:lang="da">Bestyrelsesformand</cmn:TitleOfMemberOfSupervisoryBoard>
-  <cmn:TypeOfAuditorAssistance contextRef="ID_0" xml:lang="da">Erklæring om udvidet gennemgang</cmn:TypeOfAuditorAssistance>
   <fsa:AccountingPoliciesAreUnchangedFromPreviousPeriod contextRef="ID_0" xml:lang="da">false</fsa:AccountingPoliciesAreUnchangedFromPreviousPeriod>
   <fsa:Assets contextRef="ID_10" xml:lang="da" unitRef="DKK" decimals="0">22755163</fsa:Assets>
   <fsa:Assets contextRef="ID_9" xml:lang="da" unitRef="DKK" decimals="0">17530647</fsa:Assets>
@@ -527,13 +503,7 @@
   <sob:ConfirmationThatFinancialStatementGivesTrueAndFairViewOfAssetsLiabilitiesEquityFinancialPositionAndResults contextRef="ID_0" xml:lang="da">Det er vores opfattelse, at årsregnskabet giver et retvisende billede af selskabets aktiver, passiver og finansielle stilling pr. 31. juli 2021 samt af resultatet af selskabets aktiviteter for regnskabsåret 1. august 2020 - 31. juli 2021.
  </sob:ConfirmationThatFinancialStatementGivesTrueAndFairViewOfAssetsLiabilitiesEquityFinancialPositionAndResults>
   <sob:DateOfApprovalOfAnnualReport contextRef="ID_0" xml:lang="da">2021-12-10</sob:DateOfApprovalOfAnnualReport>
-  <sob:IdentificationOfApprovedAnnualReport contextRef="ID_0" xml:lang="da">Ledelsen har dags dato behandlet og godkendt årsrapporten for regnskabsåret 1. august 2020 - 31. juli 2021 for Officeguru A/S.
- </sob:IdentificationOfApprovedAnnualReport>
-  <sob:ManagementsStatementAboutManagementsReview contextRef="ID_0" xml:lang="da">Ledelsesberetningen indeholder efter vores opfattelse en retvisende redegørelse for de forhold, beretningen omhandler.
- </sob:ManagementsStatementAboutManagementsReview>
   <sob:PlaceOfSignatureOfStatement contextRef="ID_0" xml:lang="da">København</sob:PlaceOfSignatureOfStatement>
-  <sob:RecommendationForApprovalOfAnnualReportByGeneralMeeting contextRef="ID_0" xml:lang="da">Årsrapporten indstilles til generalforsamlingens godkendelse.
- </sob:RecommendationForApprovalOfAnnualReportByGeneralMeeting>
   <sob:StatementByExecutiveAndSupervisoryBoards contextRef="ID_0" xml:lang="da">
 </sob:StatementByExecutiveAndSupervisoryBoards>
 </xbrli:xbrl>

--- a/__tests__/__fixtures__/report3.xml
+++ b/__tests__/__fixtures__/report3.xml
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xbrl xmlns="http://www.xbrl.org/2003/instance" xmlns:c="http://xbrl.dcca.dk/sob" xmlns:b="http://xbrl.dcca.dk/entryBalanceSheetAccountFormIncomeStatementByNature" xmlns:f="http://xbrl.dcca.dk/mrv" xmlns:e="http://xbrl.dcca.dk/arr" xmlns:d="http://xbrl.dcca.dk/cmn" xmlns:h="http://xbrl.dcca.dk/gsd" xmlns:g="http://xbrl.dcca.dk/fsa" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xbrli="http://www.xbrl.org/2003/instance" xmlns:iso4217="http://www.xbrl.org/2003/iso4217" xmlns:xbrldi="http://xbrl.org/2006/xbrldi" xmlns:link="http://www.xbrl.org/2003/linkbase" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xbrl.dcca.dk/entryBalanceSheetAccountFormIncomeStatementByNature http://archprod.service.eogs.dk/taxonomy/20201001/entryDanishGAAPBalanceSheetAccountFormIncomeStatementByNatureIncludingManagementsReviewStatisticsAndTax20201001.xsd">
+  <link:schemaRef xlink:type="simple" xlink:href="http://archprod.service.eogs.dk/taxonomy/20201001/entryDanishGAAPBalanceSheetAccountFormIncomeStatementByNatureIncludingManagementsReviewStatisticsAndTax20201001.xsd"/>
+  <g:GrossProfitLoss contextRef="c11" unitRef="u3" decimals="0">12246133</g:GrossProfitLoss>
+  <g:GrossProfitLoss contextRef="c32" unitRef="u3" decimals="0">6588301</g:GrossProfitLoss>
+  <g:EmployeeBenefitsExpense contextRef="c11" unitRef="u3" decimals="0">11203157</g:EmployeeBenefitsExpense>
+  <g:EmployeeBenefitsExpense contextRef="c32" unitRef="u3" decimals="0">5596697</g:EmployeeBenefitsExpense>
+  <g:DepreciationAmortisationExpenseAndImpairmentLossesOfPropertyPlantAndEquipmentAndIntangibleAssetsRecognisedInProfitOrLoss contextRef="c11" unitRef="u3" decimals="0">243858</g:DepreciationAmortisationExpenseAndImpairmentLossesOfPropertyPlantAndEquipmentAndIntangibleAssetsRecognisedInProfitOrLoss>
+  <g:DepreciationAmortisationExpenseAndImpairmentLossesOfPropertyPlantAndEquipmentAndIntangibleAssetsRecognisedInProfitOrLoss contextRef="c32" unitRef="u3" decimals="0">39975</g:DepreciationAmortisationExpenseAndImpairmentLossesOfPropertyPlantAndEquipmentAndIntangibleAssetsRecognisedInProfitOrLoss>
+  <g:ProfitLossFromOrdinaryOperatingActivities contextRef="c11" unitRef="u3" decimals="0">799118</g:ProfitLossFromOrdinaryOperatingActivities>
+  <g:ProfitLossFromOrdinaryOperatingActivities contextRef="c32" unitRef="u3" decimals="0">951629</g:ProfitLossFromOrdinaryOperatingActivities>
+  <g:OtherFinanceIncome contextRef="c11" unitRef="u3" decimals="0">115300</g:OtherFinanceIncome>
+  <g:OtherFinanceIncome contextRef="c32" unitRef="u3" decimals="0">11690</g:OtherFinanceIncome>
+  <g:OtherFinanceExpenses contextRef="c11" unitRef="u3" decimals="0">55911</g:OtherFinanceExpenses>
+  <g:OtherFinanceExpenses contextRef="c32" unitRef="u3" decimals="0">20954</g:OtherFinanceExpenses>
+  <g:ProfitLossFromOrdinaryActivitiesBeforeTax contextRef="c11" unitRef="u3" decimals="0">858507</g:ProfitLossFromOrdinaryActivitiesBeforeTax>
+  <g:ProfitLossFromOrdinaryActivitiesBeforeTax contextRef="c32" unitRef="u3" decimals="0">942365</g:ProfitLossFromOrdinaryActivitiesBeforeTax>
+  <g:TaxExpense contextRef="c11" unitRef="u3" decimals="0">208964</g:TaxExpense>
+  <g:TaxExpense contextRef="c32" unitRef="u3" decimals="0">213093</g:TaxExpense>
+  <g:ProfitLoss contextRef="c11" unitRef="u3" decimals="0">649543</g:ProfitLoss>
+  <g:ProfitLoss contextRef="c32" unitRef="u3" decimals="0">729272</g:ProfitLoss>
+  <g:ProfitLoss contextRef="c37" unitRef="u3" decimals="0">426544</g:ProfitLoss>
+  <g:ProfitLoss contextRef="c38" unitRef="u3" decimals="0">0</g:ProfitLoss>
+  <g:ProfitLoss contextRef="c46" unitRef="u3" decimals="0">222999</g:ProfitLoss>
+  <g:ProfitLoss contextRef="c47" unitRef="u3" decimals="0">729272</g:ProfitLoss>
+  <g:FixturesFittingsToolsAndEquipment contextRef="c49" unitRef="u3" decimals="0">1303961</g:FixturesFittingsToolsAndEquipment>
+  <g:FixturesFittingsToolsAndEquipment contextRef="c48" unitRef="u3" decimals="0">183810</g:FixturesFittingsToolsAndEquipment>
+  <g:PropertyPlantAndEquipment contextRef="c49" unitRef="u3" decimals="0">1303961</g:PropertyPlantAndEquipment>
+  <g:PropertyPlantAndEquipment contextRef="c48" unitRef="u3" decimals="0">183810</g:PropertyPlantAndEquipment>
+  <g:DepositsLongtermInvestmentsAndReceivables contextRef="c49" unitRef="u3" decimals="0">334875</g:DepositsLongtermInvestmentsAndReceivables>
+  <g:DepositsLongtermInvestmentsAndReceivables contextRef="c48" unitRef="u3" decimals="0">26250</g:DepositsLongtermInvestmentsAndReceivables>
+  <g:LongtermInvestmentsAndReceivables contextRef="c49" unitRef="u3" decimals="0">334875</g:LongtermInvestmentsAndReceivables>
+  <g:LongtermInvestmentsAndReceivables contextRef="c48" unitRef="u3" decimals="0">26250</g:LongtermInvestmentsAndReceivables>
+  <g:NoncurrentAssets contextRef="c49" unitRef="u3" decimals="0">1638836</g:NoncurrentAssets>
+  <g:NoncurrentAssets contextRef="c48" unitRef="u3" decimals="0">210060</g:NoncurrentAssets>
+  <g:RawMaterialsAndConsumables contextRef="c49" unitRef="u3" decimals="0">165000</g:RawMaterialsAndConsumables>
+  <g:RawMaterialsAndConsumables contextRef="c48" unitRef="u3" decimals="0">70000</g:RawMaterialsAndConsumables>
+  <g:Inventories contextRef="c49" unitRef="u3" decimals="0">165000</g:Inventories>
+  <g:Inventories contextRef="c48" unitRef="u3" decimals="0">70000</g:Inventories>
+  <g:ShorttermTradeReceivables contextRef="c49" unitRef="u3" decimals="0">5497803</g:ShorttermTradeReceivables>
+  <g:ShorttermTradeReceivables contextRef="c48" unitRef="u3" decimals="0">2927012</g:ShorttermTradeReceivables>
+  <g:OtherShorttermReceivables contextRef="c49" unitRef="u3" decimals="0">631963</g:OtherShorttermReceivables>
+  <g:OtherShorttermReceivables contextRef="c48" unitRef="u3" decimals="0">69099</g:OtherShorttermReceivables>
+  <g:ShorttermReceivablesFromOwnersAndManagement contextRef="c49" unitRef="u3" decimals="0">0</g:ShorttermReceivablesFromOwnersAndManagement>
+  <g:ShorttermReceivablesFromOwnersAndManagement contextRef="c48" unitRef="u3" decimals="0">296269</g:ShorttermReceivablesFromOwnersAndManagement>
+  <g:CurrentDeferredTaxAssets contextRef="c49" unitRef="u3" decimals="0">0</g:CurrentDeferredTaxAssets>
+  <g:CurrentDeferredTaxAssets contextRef="c48" unitRef="u3" decimals="0">3354</g:CurrentDeferredTaxAssets>
+  <g:DeferredIncomeAssets contextRef="c49" unitRef="u3" decimals="0">726041</g:DeferredIncomeAssets>
+  <g:DeferredIncomeAssets contextRef="c48" unitRef="u3" decimals="0">131329</g:DeferredIncomeAssets>
+  <g:ShorttermReceivables contextRef="c49" unitRef="u3" decimals="0">6855807</g:ShorttermReceivables>
+  <g:ShorttermReceivables contextRef="c48" unitRef="u3" decimals="0">3427063</g:ShorttermReceivables>
+  <g:CashAndCashEquivalents contextRef="c49" unitRef="u3" decimals="0">92870</g:CashAndCashEquivalents>
+  <g:CashAndCashEquivalents contextRef="c48" unitRef="u3" decimals="0">0</g:CashAndCashEquivalents>
+  <g:CurrentAssets contextRef="c49" unitRef="u3" decimals="0">7113677</g:CurrentAssets>
+  <g:CurrentAssets contextRef="c48" unitRef="u3" decimals="0">3497063</g:CurrentAssets>
+  <g:Assets contextRef="c49" unitRef="u3" decimals="0">8752513</g:Assets>
+  <g:Assets contextRef="c48" unitRef="u3" decimals="0">3707123</g:Assets>
+  <g:ContributedCapital contextRef="c49" unitRef="u3" decimals="0">50000</g:ContributedCapital>
+  <g:ContributedCapital contextRef="c48" unitRef="u3" decimals="0">50000</g:ContributedCapital>
+  <g:RetainedEarnings contextRef="c49" unitRef="u3" decimals="0">1668822</g:RetainedEarnings>
+  <g:RetainedEarnings contextRef="c48" unitRef="u3" decimals="0">1445824</g:RetainedEarnings>
+  <g:Equity contextRef="c49" unitRef="u3" decimals="0">1718822</g:Equity>
+  <g:Equity contextRef="c48" unitRef="u3" decimals="0">1495824</g:Equity>
+  <g:ProvisionsForDeferredTax contextRef="c49" unitRef="u3" decimals="0">191332</g:ProvisionsForDeferredTax>
+  <g:ProvisionsForDeferredTax contextRef="c48" unitRef="u3" decimals="0">0</g:ProvisionsForDeferredTax>
+  <g:Provisions contextRef="c49" unitRef="u3" decimals="0">191332</g:Provisions>
+  <g:Provisions contextRef="c48" unitRef="u3" decimals="0">0</g:Provisions>
+  <g:ShorttermDebtToOtherCreditInstitutions contextRef="c49" unitRef="u3" decimals="0">209130</g:ShorttermDebtToOtherCreditInstitutions>
+  <g:ShorttermDebtToOtherCreditInstitutions contextRef="c48" unitRef="u3" decimals="0">94174</g:ShorttermDebtToOtherCreditInstitutions>
+  <g:ShorttermTradePayables contextRef="c49" unitRef="u3" decimals="0">1382246</g:ShorttermTradePayables>
+  <g:ShorttermTradePayables contextRef="c48" unitRef="u3" decimals="0">574773</g:ShorttermTradePayables>
+  <g:ShorttermPayablesToGroupEnterprises contextRef="c49" unitRef="u3" decimals="0">502229</g:ShorttermPayablesToGroupEnterprises>
+  <g:ShorttermPayablesToGroupEnterprises contextRef="c48" unitRef="u3" decimals="0">291986</g:ShorttermPayablesToGroupEnterprises>
+  <g:ShorttermPayablesToShareholdersAndManagement contextRef="c49" unitRef="u3" decimals="0">2904</g:ShorttermPayablesToShareholdersAndManagement>
+  <g:ShorttermPayablesToShareholdersAndManagement contextRef="c48" unitRef="u3" decimals="0">0</g:ShorttermPayablesToShareholdersAndManagement>
+  <g:ShorttermTaxPayables contextRef="c49" unitRef="u3" decimals="0">14278</g:ShorttermTaxPayables>
+  <g:ShorttermTaxPayables contextRef="c48" unitRef="u3" decimals="0">217118</g:ShorttermTaxPayables>
+  <g:OtherShorttermPayables contextRef="c49" unitRef="u3" decimals="0">4731572</g:OtherShorttermPayables>
+  <g:OtherShorttermPayables contextRef="c48" unitRef="u3" decimals="0">1033248</g:OtherShorttermPayables>
+  <g:ShorttermLiabilitiesOtherThanProvisions contextRef="c49" unitRef="u3" decimals="0">6842359</g:ShorttermLiabilitiesOtherThanProvisions>
+  <g:ShorttermLiabilitiesOtherThanProvisions contextRef="c48" unitRef="u3" decimals="0">2211299</g:ShorttermLiabilitiesOtherThanProvisions>
+  <g:LiabilitiesOtherThanProvisions contextRef="c49" unitRef="u3" decimals="0">6842359</g:LiabilitiesOtherThanProvisions>
+  <g:LiabilitiesOtherThanProvisions contextRef="c48" unitRef="u3" decimals="0">2211299</g:LiabilitiesOtherThanProvisions>
+  <g:LiabilitiesAndEquity contextRef="c49" unitRef="u3" decimals="0">8752513</g:LiabilitiesAndEquity>
+  <g:LiabilitiesAndEquity contextRef="c48" unitRef="u3" decimals="0">3707123</g:LiabilitiesAndEquity>
+  <g:Equity contextRef="c87" unitRef="u3" decimals="0">50000</g:Equity>
+  <g:Equity contextRef="c105" unitRef="u3" decimals="0">1445823</g:Equity>
+  <g:Equity contextRef="c472" unitRef="u3" decimals="0">0</g:Equity>
+  <g:ProfitLoss contextRef="c106" unitRef="u3" decimals="0">222999</g:ProfitLoss>
+  <g:ProfitLoss contextRef="c473" unitRef="u3" decimals="0">426544</g:ProfitLoss>
+  <g:Equity contextRef="c89" unitRef="u3" decimals="0">50000</g:Equity>
+  <g:Equity contextRef="c107" unitRef="u3" decimals="0">1668822</g:Equity>
+  <g:Equity contextRef="c474" unitRef="u3" decimals="0">0</g:Equity>
+  <g:WagesAndSalaries contextRef="c11" unitRef="u3" decimals="0">10114279</g:WagesAndSalaries>
+  <g:WagesAndSalaries contextRef="c32" unitRef="u3" decimals="0">4934752</g:WagesAndSalaries>
+  <g:PostemploymentBenefitExpense contextRef="c11" unitRef="u3" decimals="0">985927</g:PostemploymentBenefitExpense>
+  <g:PostemploymentBenefitExpense contextRef="c32" unitRef="u3" decimals="0">413460</g:PostemploymentBenefitExpense>
+  <g:SocialSecurityContributions contextRef="c11" unitRef="u3" decimals="0">102951</g:SocialSecurityContributions>
+  <g:SocialSecurityContributions contextRef="c32" unitRef="u3" decimals="0">248485</g:SocialSecurityContributions>
+  <g:EmployeeBenefitsExpense contextRef="c11" unitRef="u3" decimals="0">11203157</g:EmployeeBenefitsExpense>
+  <g:EmployeeBenefitsExpense contextRef="c32" unitRef="u3" decimals="0">5596697</g:EmployeeBenefitsExpense>
+  <g:AverageNumberOfEmployees contextRef="c11" unitRef="u4" decimals="INF">22</g:AverageNumberOfEmployees>
+  <g:AverageNumberOfEmployees contextRef="c32" unitRef="u4" decimals="INF">14</g:AverageNumberOfEmployees>
+  <g:CurrentTaxExpense contextRef="c11" unitRef="u3" decimals="0">14278</g:CurrentTaxExpense>
+  <g:CurrentTaxExpense contextRef="c32" unitRef="u3" decimals="0">217118</g:CurrentTaxExpense>
+  <g:AdjustmentsForDeferredTax contextRef="c11" unitRef="u3" decimals="0">194686</g:AdjustmentsForDeferredTax>
+  <g:AdjustmentsForDeferredTax contextRef="c32" unitRef="u3" decimals="0">-6489</g:AdjustmentsForDeferredTax>
+  <g:AdjustmentsForCurrentTaxOfPriorPeriod contextRef="c11" unitRef="u3" decimals="0">0</g:AdjustmentsForCurrentTaxOfPriorPeriod>
+  <g:AdjustmentsForCurrentTaxOfPriorPeriod contextRef="c32" unitRef="u3" decimals="0">2464</g:AdjustmentsForCurrentTaxOfPriorPeriod>
+  <g:PropertyPlantAndEquipmentGross contextRef="c184" unitRef="u3" decimals="0">223785</g:PropertyPlantAndEquipmentGross>
+  <g:AdditionsToPropertyPlantAndEquipment contextRef="c185" unitRef="u3" decimals="0">1364009</g:AdditionsToPropertyPlantAndEquipment>
+  <g:PropertyPlantAndEquipmentGross contextRef="c186" unitRef="u3" decimals="0">1587794</g:PropertyPlantAndEquipmentGross>
+  <g:AccumulatedImpairmentLossesAndDepreciationOfPropertyPlantAndEquipment contextRef="c184" unitRef="u3" decimals="0">39975</g:AccumulatedImpairmentLossesAndDepreciationOfPropertyPlantAndEquipment>
+  <g:DepreciationOfPropertyPlantAndEquipment contextRef="c185" unitRef="u3" decimals="0">243858</g:DepreciationOfPropertyPlantAndEquipment>
+  <g:AccumulatedImpairmentLossesAndDepreciationOfPropertyPlantAndEquipment contextRef="c186" unitRef="u3" decimals="0">-283833</g:AccumulatedImpairmentLossesAndDepreciationOfPropertyPlantAndEquipment>
+  <g:PropertyPlantAndEquipment contextRef="c186" unitRef="u3" decimals="0">1303961</g:PropertyPlantAndEquipment>
+  <g:InvestmentsGross contextRef="c947" unitRef="u3" decimals="0">26250</g:InvestmentsGross>
+  <g:AdditionsToInvestments contextRef="c948" unitRef="u3" decimals="0">334875</g:AdditionsToInvestments>
+  <g:DisposalsOfInvestments contextRef="c948" unitRef="u3" decimals="0">-26250</g:DisposalsOfInvestments>
+  <g:InvestmentsGross contextRef="c949" unitRef="u3" decimals="0">334875</g:InvestmentsGross>
+  <g:LongtermInvestmentsAndReceivables contextRef="c949" unitRef="u3" decimals="0">334875</g:LongtermInvestmentsAndReceivables>
+  <h:InformationOnTypeOfSubmittedReport contextRef="c11">Årsrapport</h:InformationOnTypeOfSubmittedReport>
+  <h:IdentificationNumberCvrOfSubmittingEnterprise contextRef="c11">36074981</h:IdentificationNumberCvrOfSubmittingEnterprise>
+  <h:NameOfSubmittingEnterprise contextRef="c11">Boreco</h:NameOfSubmittingEnterprise>
+  <h:ReportingPeriodStartDate contextRef="c11">2020-01-01</h:ReportingPeriodStartDate>
+  <h:ReportingPeriodEndDate contextRef="c11">2020-12-31</h:ReportingPeriodEndDate>
+  <h:PrecedingReportingPeriodStartDate contextRef="c11">2019-01-01</h:PrecedingReportingPeriodStartDate>
+  <h:PredingReportingPeriodEndDate contextRef="c11">2019-12-31</h:PredingReportingPeriodEndDate>
+  <h:IdentificationNumberCvrOfReportingEntity contextRef="c11">38343521</h:IdentificationNumberCvrOfReportingEntity>
+  <h:NameOfReportingEntity contextRef="c11">C.C Rengøring &amp; Facility ApS</h:NameOfReportingEntity>
+  <h:AddressOfReportingEntityStreetName contextRef="c11">Fabriksparken</h:AddressOfReportingEntityStreetName>
+  <h:AddressOfReportingEntityStreetBuildingIdentifier contextRef="c11">38</h:AddressOfReportingEntityStreetBuildingIdentifier>
+  <h:AddressOfReportingEntityPostCodeIdentifier contextRef="c11">2600</h:AddressOfReportingEntityPostCodeIdentifier>
+  <h:AddressOfReportingEntityDistrictName contextRef="c11">Glostrup</h:AddressOfReportingEntityDistrictName>
+  <h:AddressOfReportingEntityCountryIdentificationCode contextRef="c11">DK</h:AddressOfReportingEntityCountryIdentificationCode>
+  <h:AddressOfReportingEntityCountry contextRef="c11">Danmark</h:AddressOfReportingEntityCountry>
+  <h:DateOfFoundationOfReportingEntity contextRef="c11">2017-01-17</h:DateOfFoundationOfReportingEntity>
+  <h:RegisteredOfficeOfReportingEntity contextRef="c11">Albertslund</h:RegisteredOfficeOfReportingEntity>
+  <d:NameOfAuditFirm contextRef="c12">Boreco</d:NameOfAuditFirm>
+  <d:IdentificationNumberCvrOfAuditFirm contextRef="c12">36074981</d:IdentificationNumberCvrOfAuditFirm>
+  <d:NameAndSurnameOfAuditor contextRef="c12">Morten Plenge</d:NameAndSurnameOfAuditor>
+  <d:DescriptionOfAuditor contextRef="c12">statsautoriseret revisor</d:DescriptionOfAuditor>
+  <h:AddressOfAuditorStreetName contextRef="c12">Vindingevej</h:AddressOfAuditorStreetName>
+  <h:AddressOfAuditorStreetBuildingIdentifier contextRef="c12">10</h:AddressOfAuditorStreetBuildingIdentifier>
+  <h:AddressOfAuditorPostCodeIdentifier contextRef="c12">4000</h:AddressOfAuditorPostCodeIdentifier>
+  <h:AddressOfAuditorDistrictName contextRef="c12">Roskilde</h:AddressOfAuditorDistrictName>
+  <h:AddressOfAuditorCountryIdentificationCode contextRef="c12">DK</h:AddressOfAuditorCountryIdentificationCode>
+  <h:AddressOfAuditorCountry contextRef="c12">Danmark</h:AddressOfAuditorCountry>
+  <h:DateOfGeneralMeeting contextRef="c11">2021-03-19</h:DateOfGeneralMeeting>
+  <h:NameAndSurnameOfChairmanOfGeneralMeeting contextRef="c11">Lavdrim Camili</h:NameAndSurnameOfChairmanOfGeneralMeeting>
+  <g:ClassOfReportingEntity contextRef="c11">Regnskabsklasse B</g:ClassOfReportingEntity>
+  <g:SelectedElementsFromReportingClassC contextRef="c11">true</g:SelectedElementsFromReportingClassC>
+  <d:TypeOfAuditorAssistance contextRef="c11">Revisionspåtegning</d:TypeOfAuditorAssistance>
+  <h:ToolForPreparingTheXBRLInstanceDocument contextRef="c11">CaseWare-FSR</h:ToolForPreparingTheXBRLInstanceDocument>
+  <e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyTheCriminalCodeAndFiscalTaxAndSubsidyLegislationAudit contextRef="c11">true</e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyTheCriminalCodeAndFiscalTaxAndSubsidyLegislationAudit>
+  <e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyTheCompaniesActOrEquivalentLegislationThatTheCompanyIsSubjectToAudit contextRef="c11">false</e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyTheCompaniesActOrEquivalentLegislationThatTheCompanyIsSubjectToAudit>
+  <e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsAudit contextRef="c11">false</e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsAudit>
+  <e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyOtherMattersAudit contextRef="c11">false</e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyOtherMattersAudit>
+  <!--Aktuelle periode enkelt selskab-->
+  <context id="c11">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+  </context>
+  <!--REVISOR1-->
+  <context id="c12">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:typedMember dimension="d:IdentificationOfAuditorDimension">
+        <d:auditorIdentifier>1</d:auditorIdentifier>
+      </xbrldi:typedMember>
+    </scenario>
+  </context>
+  <!--Forrige periode enkelt selskab-->
+  <context id="c32">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2019-01-01</startDate>
+      <endDate>2019-12-31</endDate>
+    </period>
+  </context>
+  <!--Udbytte aconto aktuel i aaret-->
+  <context id="c37">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ResultDistributionDimension">g:ProposedExtraordinaryDividendRecognisedInEquityMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Udbytte aconto forrige i aaret-->
+  <context id="c38">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2019-01-01</startDate>
+      <endDate>2019-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ResultDistributionDimension">g:ProposedExtraordinaryDividendRecognisedInEquityMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Overfoert resultat aktuel i aaret-->
+  <context id="c46">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ResultDistributionDimension">g:RetainedEarningsMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Overfoert resultat forrige i aaret-->
+  <context id="c47">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2019-01-01</startDate>
+      <endDate>2019-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ResultDistributionDimension">g:RetainedEarningsMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Slutdato forrige periode enkelt selskab-->
+  <context id="c48">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2019-12-31</instant>
+    </period>
+  </context>
+  <!--Slutdato aktuelle periode enkelt selskab-->
+  <context id="c49">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-12-31</instant>
+    </period>
+  </context>
+  <!--CEO1-->
+  <context id="c78">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:typedMember dimension="d:IdentificationOfMemberOfExecutiveBoardDimension">
+        <d:memberOfBoardIdentifier>1</d:memberOfBoardIdentifier>
+      </xbrldi:typedMember>
+    </scenario>
+  </context>
+  <!--Virksomhedskapital aktuel primo-->
+  <context id="c87">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-01-01</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:ContributedCapitalMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Virksomhedskapital aktuel ultimo-->
+  <context id="c89">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-12-31</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:ContributedCapitalMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Overfort res aktuel primo-->
+  <context id="c105">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-01-01</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:RetainedEarningsMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Overfort res aktuel i aaret-->
+  <context id="c106">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:RetainedEarningsMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Overfort res aktuel ultimo-->
+  <context id="c107">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-12-31</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:RetainedEarningsMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Andre anlag aktuel primo-->
+  <context id="c184">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-01-01</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfPropertyPlantAndEquipmentDimension">g:FixturesFittingsToolsAndEquipmentMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Andre anlag aktuel i aaret-->
+  <context id="c185">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfPropertyPlantAndEquipmentDimension">g:FixturesFittingsToolsAndEquipmentMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Andre anlag aktuel ultimo-->
+  <context id="c186">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-12-31</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfPropertyPlantAndEquipmentDimension">g:FixturesFittingsToolsAndEquipmentMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Ekstraordinart udbytte aktuel primo-->
+  <context id="c472">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-01-01</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:ProposedExtraordinaryDividendRecognisedInEquityMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Ekstraordinart udbytte aktuel i aaret-->
+  <context id="c473">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:ProposedExtraordinaryDividendRecognisedInEquityMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Ekstraordinart udbytte aktuel ultimo-->
+  <context id="c474">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-12-31</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfEquityDimension">g:ProposedExtraordinaryDividendRecognisedInEquityMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Deposita aktuel primo-->
+  <context id="c947">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-01-01</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfInvestmentsDimension">g:DepositsLongtermInvestmentsAndReceivablesMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Deposita aktuel i aaret-->
+  <context id="c948">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <startDate>2020-01-01</startDate>
+      <endDate>2020-12-31</endDate>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfInvestmentsDimension">g:DepositsLongtermInvestmentsAndReceivablesMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--Deposita aktuel ultimo-->
+  <context id="c949">
+    <entity>
+      <identifier scheme="http://www.dcca.dk/cvr">38343521</identifier>
+    </entity>
+    <period>
+      <instant>2020-12-31</instant>
+    </period>
+    <scenario>
+      <xbrldi:explicitMember dimension="g:ClassesOfInvestmentsDimension">g:DepositsLongtermInvestmentsAndReceivablesMember</xbrldi:explicitMember>
+    </scenario>
+  </context>
+  <!--DKK enere-->
+  <unit id="u3">
+    <measure>iso4217:DKK</measure>
+  </unit>
+  <!--Antal-->
+  <unit id="u4">
+    <measure>xbrli:pure</measure>
+  </unit>
+</xbrl>

--- a/__tests__/util.ts
+++ b/__tests__/util.ts
@@ -1,0 +1,7 @@
+import fs from 'fs';
+import path from 'path';
+
+export function loadReport(num: number): string {
+  const file = path.join(__dirname, './__fixtures__', `report${num}.xml`);
+  return fs.readFileSync(file, 'utf-8');
+}

--- a/__tests__/xbrl.test.ts
+++ b/__tests__/xbrl.test.ts
@@ -1,17 +1,10 @@
-import fs from 'fs';
-import path from 'path';
 import { parseXbrlFile } from '../src/index.js';
+import { loadReport } from './util.js';
 
 describe('xbrl', () => {
-  let xmlString: string;
-
-  beforeAll(async () => {
-    const file = path.join(__dirname, './__fixtures__', 'report1.xml');
-    xmlString = fs.readFileSync(file, 'utf-8');
-  });
-
   it('should parse a XBRL file and return raw document', () => {
-    const xbrl = parseXbrlFile(xmlString);
+    const xbrl = parseXbrlFile(loadReport(1));
+    expect(xbrl['?xml']).toBeTruthy();
     expect(xbrl['xbrli:xbrl']?.['xbrli:context']).toContainEqual(expect.objectContaining({
       'xbrli:entity': {
         'xbrli:identifier': {
@@ -25,5 +18,25 @@ describe('xbrl', () => {
       },
       '@_id': 'ctx1'
     }));
+    expect(xbrl['xbrli:xbrl']?.['fsa:ProfitLoss']).toBeTruthy();
+  });
+
+  it('should parse a XBRL file with different namespaces', () => {
+    const xbrl = parseXbrlFile(loadReport(3));
+    expect(xbrl['?xml']).toBeTruthy();
+    expect(xbrl['xbrli:xbrl']?.['xbrli:context']).toContainEqual(expect.objectContaining({
+      'xbrli:entity': {
+        'xbrli:identifier': {
+          '#text': 38343521,
+          '@_scheme': 'http://www.dcca.dk/cvr'
+        }
+      },
+      'xbrli:period': {
+        'xbrli:startDate': '2020-01-01',
+        'xbrli:endDate': '2020-12-31'
+      },
+      '@_id': 'c11'
+    }));
+    expect(xbrl['xbrli:xbrl']?.['fsa:ProfitLoss']).toBeTruthy();
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,4 +10,5 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
+  testMatch: ['**/__tests__/**/*.test.ts'],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { parseXbrlFile } from './xbrl/index.js';
 import { default as CvrParser } from './parsers/cvr.js';
+export * from './types.js';
 import type { Parser } from './parsers/parser';
 
 /**

--- a/src/parsers/cvr.ts
+++ b/src/parsers/cvr.ts
@@ -1,8 +1,8 @@
 import { findInstants, findPeriods, Instant, parseXbrlFile, Period } from '../xbrl/index.js';
+import { ensureArray } from '../util.js';
 import type { AnnualReport, Balance, IncomeStatement } from '../types';
 import type { NumberWithUnitRef, XbrliXbrl } from '../xbrl/types';
 import type { Parser } from './parser';
-import { ensureArray } from '../util.js';
 
 /**
  * Parser that understands the XBRL taxonomy for many Danish companies as fetched from CVR.

--- a/src/xbrl/index.ts
+++ b/src/xbrl/index.ts
@@ -1,6 +1,8 @@
 import { XMLParser } from 'fast-xml-parser';
 import type { XBRLDocument, XbrliXbrl } from './types';
 
+type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
+
 export interface Period {
   id: string;
   startDate: string;
@@ -17,7 +19,87 @@ export function parseXbrlFile(xmlString: string): XBRLDocument {
     ignoreAttributes: false,
   }).parse(xmlString);
 
+  const xbrliRootKey = Object.keys(obj).find(k => k.includes('xbrl'));
+  if (!xbrliRootKey) {
+    throw new Error('xbrlRootNotFound: Could not find xbrl root in the file');
+  }
+
+  obj['xbrli:xbrl'] = transformNamespaces(obj[xbrliRootKey]);
   return obj as XBRLDocument;
+}
+
+function transformNamespaces(obj: { [key: string]: Json }): unknown {
+  // See XBRL spec notes in the readme for more info on this cleaning
+
+  const namespaces = Object.entries(obj)
+    .filter(([k]) => k.startsWith('@_xmlns')) as [string, string][];
+
+  // Namespaces to update
+  const namespaceMapping: Record<string, string> = {};
+
+  // namespaces is a list of pairs like ['@_xmlns:xbrli', 'http://www.xbrl.org/2003/instance']
+  for (const [xmlns, namespaceUrl] of namespaces) {
+    // Might look like xmlns:xbrli or simply xmlns (without colon)
+    const name = xmlns.split(':')[1] || '';
+
+    // Not all namespaces are explicitly checked
+
+    // The instance objects should be prefixed xbrli
+    if (namespaceUrl === 'http://www.xbrl.org/2003/instance' && name !== 'xbrli') {
+      namespaceMapping[name] = 'xbrli';
+    }
+
+    // Danish-specific namespaces match xbrl.dcca.dk/[thenamespacename]
+    // Matches e.g. "fsa" and checks if the namespace already has that name.
+    const daMatches = namespaceUrl.match(/xbrl\.dcca\.dk\/(\w+)/i);
+    if (daMatches && daMatches[1] && daMatches[1] !== name) {
+      namespaceMapping[name] = daMatches[1];
+    }
+  }
+
+  if (Object.keys(namespaceMapping).length) {
+    return recursiveNamespaceTransform(obj as Json, namespaceMapping);
+  }
+
+  return obj;
+}
+
+function isLeaf(obj: Json): boolean {
+  return (obj === null || typeof obj === 'string' || typeof obj === 'number' || typeof obj === 'boolean');
+}
+
+function recursiveNamespaceTransform(obj: Json, namespaceMapping: Record<string, string>): Json {
+  if (Array.isArray(obj)) {
+    return obj.map(v => recursiveNamespaceTransform(v, namespaceMapping));
+  }
+
+  if (isLeaf(obj)) {
+    return obj;
+  }
+
+  const newObj = Object.entries(obj as Record<string, Json>)
+    .reduce<Record<string, Json>>((newObj, [key, value]) => {
+      // Don't transform #text and attributes
+      if (key === '#text' || key.startsWith('@_')) {
+        newObj[key] = value;
+        return newObj;
+      }
+
+      // E.g. a:ProfitLoss might be renamed to fsa:ProfitLoss
+      const split = key.split(':');
+      let namespace = split[0];
+      let name = split[1] || '';
+      // Handle special case for empty namespace
+      if (name === '') {
+        name = namespace;
+        namespace = '';
+      }
+
+      const newNamespace = namespaceMapping[namespace] ? namespaceMapping[namespace] : namespace;
+      newObj[`${newNamespace}:${name}`] = recursiveNamespaceTransform(value, namespaceMapping);
+      return newObj;
+    }, {});
+  return newObj;
 }
 
 export function findPeriods(doc: XbrliXbrl): ({ VAT: string } & Period)[] {

--- a/src/xbrl/types.ts
+++ b/src/xbrl/types.ts
@@ -1,260 +1,16 @@
-// Created by quicktype. The names might not make sense. Some of them are renamed manually.
-// Some extra types have been added based on taxonomies.
+// Initially created by quicktype.
+// - The names might not make sense.
+// - Some of them are renamed manually.
+// - Some extra types have been added based on taxonomies.
 
 export interface XBRLDocument {
   '?xml': XML;
   'xbrli:xbrl'?: XbrliXbrl;
-  xbrl?: Xbrl;
-  '?instance-generator'?: InstanceGenerator;
-}
-
-export interface InstanceGenerator {
-  '@_id': string;
-  '@_version': string;
-  '@_creationdate': string;
 }
 
 export interface XML {
   '@_version': string;
   '@_encoding': string;
-}
-
-export interface Xbrl {
-  'link:schemaRef': LinkSchemaRef;
-  'c:IdentificationOfApprovedAnnualReport': StringNode;
-  'c:ConfirmationThatAnnualReportIsPresentedInAccordanceWithRequirementsProvidedForByLegislationAnyStandardsAndRequirementsProvidedByArticlesOfAssociationOrByAgreement': StringNode;
-  'c:ConfirmationThatFinancialStatementGivesTrueAndFairViewOfAssetsLiabilitiesEquityFinancialPositionAndResults': StringNode;
-  'c:ManagementsStatementAboutManagementsReview': StringNode;
-  'c:RecommendationForApprovalOfAnnualReportByGeneralMeeting': StringNode;
-  'd:NameAndSurnameOfMemberOfExecutiveBoard': StringNode[] | StringNode;
-  'e:AddresseeOfAuditorsReportOnExtendedReviewOfFinancialStatements'?: StringNode;
-  'e:OpinionOnFinancialStatementsExtendedReview'?: StringNode;
-  'e:DescriptionOfQualificationsOfFinancialStatementsExtendedReview'?: StringNode;
-  'e:StatementOfExecutiveAndSupervisoryBoardsResponsibilityForFinancialStatementsExtendedReview'?: StringNode;
-  'e:StatementOfAuditorsResponsibilityExtendedReview'?: StringNode;
-  'e:StatementOnManagementsReviewAuditorsReportOnExtendedReviewFinancialStatementsExtendedReview'?: StringNode;
-  'e:SignatureOfAuditorsPlace'?: StringNode;
-  'e:SignatureOfAuditorsDate'?: StringNode;
-  'd:NameOfAuditFirm'?: StringNode[];
-  'd:NameAndSurnameOfAuditor'?: StringNode[];
-  'd:DescriptionOfAuditor'?: StringNode[];
-  'd:IdentificationNumberOfAuditor'?: StringNode;
-  'f:DescriptionOfPrimaryActivitiesOfEntity'?: StringNode;
-  'f:DescriptionOfBranchesAbroad'?: StringNode;
-  'g:GrossProfitLoss'?: NumberWithUnitRef[];
-  'g:EmployeeBenefitsExpense'?: NumberWithUnitRef[];
-  'g:DepreciationAmortisationExpenseAndImpairmentLossesOfPropertyPlantAndEquipmentAndIntangibleAssetsRecognisedInProfitOrLoss'?: NumberWithUnitRef[];
-  'g:OtherOperatingExpenses'?: NumberWithUnitRef[];
-  'g:ProfitLossFromOrdinaryOperatingActivities'?: NumberWithUnitRef[];
-  'g:IncomeFromInvestmentsInGroupEnterprises'?: NumberWithUnitRef[];
-  'g:OtherFinanceIncome'?: NumberWithUnitRef[];
-  'g:OtherFinanceExpenses'?: NumberWithUnitRef[];
-  'g:ProfitLossFromOrdinaryActivitiesBeforeTax'?: NumberWithUnitRef[];
-  'g:TaxExpense'?: NumberWithUnitRef[];
-  'g:ProfitLoss'?: NumberWithUnitRef[];
-  'g:CompletedDevelopmentProjects'?: NumberWithUnitRef[];
-  'g:Goodwill'?: NumberWithUnitRef[];
-  'g:IntangibleAssets'?: NumberWithUnitRef[];
-  'g:FixturesFittingsToolsAndEquipment'?: NumberWithUnitRef[];
-  'g:LeaseholdImprovements'?: NumberWithUnitRef[];
-  'g:PropertyPlantAndEquipment'?: NumberWithUnitRef[];
-  'g:NoncurrentAssets'?: NumberWithUnitRef[];
-  'g:ManufacturedGoodsAndGoodsForResale'?: NumberWithUnitRef[];
-  'g:Inventories'?: NumberWithUnitRef[];
-  'g:ShorttermTradeReceivables'?: NumberWithUnitRef[];
-  'g:OtherShorttermReceivables'?: NumberWithUnitRef[];
-  'g:ShorttermTaxReceivables'?: NumberWithUnitRef[];
-  'g:DeferredIncomeAssets'?: NumberWithUnitRef[];
-  'g:ShorttermReceivables'?: NumberWithUnitRef[];
-  'g:CashAndCashEquivalents'?: NumberWithUnitRef[];
-  'g:CurrentAssets'?: NumberWithUnitRef[];
-  'g:Assets'?: NumberWithUnitRef[];
-  'g:ContributedCapital'?: NumberWithUnitRef[];
-  'g:ReserveForDevelopmentExpenditure'?: NumberWithUnitRef[];
-  'g:RetainedEarnings'?: NumberWithUnitRef[];
-  'g:Equity'?: NumberWithUnitRef[];
-  'g:ProvisionsForDeferredTax'?: NumberWithUnitRef[];
-  'g:Provisions'?: NumberWithUnitRef[];
-  'g:ShorttermPrepaymentsReceivedFromCustomers'?: NumberWithUnitRef[];
-  'g:ShorttermTradePayables'?: NumberWithUnitRef[];
-  'g:ShorttermPayablesToShareholdersAndManagement'?: NumberWithUnitRef[];
-  'g:ShorttermTaxPayables'?: NumberWithUnitRef[];
-  'g:OtherShorttermPayables'?: NumberWithUnitRef[];
-  'g:ShorttermLiabilitiesOtherThanProvisions'?: NumberWithUnitRef[];
-  'g:LiabilitiesOtherThanProvisions'?: NumberWithUnitRef[];
-  'g:LiabilitiesAndEquity'?: NumberWithUnitRef[];
-  'g:EquityTransfersToReserves'?: NumberWithUnitRef[];
-  'g:InformationOnReportingClassOfEntity'?: StringNode;
-  'g:DescriptionOfGeneralMattersRelatedToRecognitionMeasurementAndChangesInAccountingPolicies'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfGrossProfitLoss'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfRevenue'?: StringNode;
-  'g:DescriptionOfRawMaterialsAndConsumablesUsed'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfOtherOperatingExpenses'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfExternalExpenses'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfEmployeeBenefitExpense'?: StringNode;
-  'g:DescriptionOfMethodsOfImpairmentLossesAndDepreciation'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfFinanceIncomeAndExpenses'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfTaxExpenses'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfIntangibleAssets'?: StringNode;
-  'g:ExplanationOfAmortizationPeriodForGoodwill'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfPropertyPlantAndEquipment'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisForInvestmentsInSubsidiariesAndAssociates'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfInventories'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfReceivables'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfContractWorkInProgress'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfDeferredIncomeAssets'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfCashAndCashEquivalents'?: StringNode;
-  'g:DescriptionOfMethodsOfDividends'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfTaxPayablesAndDeferredTax'?: StringNode;
-  'g:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfLiabilitiesOtherThanProvisions'?: StringNode;
-  'g:DescriptionOfMethodsOfForeignCurrencies'?: StringNode;
-  'g:WagesAndSalaries'?: NumberWithUnitRef[];
-  'g:PostemploymentBenefitExpense'?: NumberWithUnitRef[];
-  'g:SocialSecurityContributions'?: NumberWithUnitRef[];
-  'g:EmployeeExpensesTransferredToAssets'?: NumberWithUnitRef[];
-  'g:AverageNumberOfEmployees'?: NumberWithUnitRef[];
-  'g:AmortisationOfIntangibleAssets'?: NumberWithUnitRef[];
-  'g:DepreciationOfPropertyPlantAndEquipment'?: NumberWithUnitRef[];
-  'g:OtherInterestIncome'?: NumberWithUnitRef[];
-  'g:InterestExpenseToParticipatingInterests'?: NumberWithUnitRef[];
-  'g:OtherInterestExpenses'?: NumberWithUnitRef[];
-  'g:IntangibleAssetsGross'?: NumberWithUnitRef[];
-  'g:AccumulatedImpairmentLossesAndAmortisationOfIntangibleAssets'?: NumberWithUnitRef[];
-  'g:fInformationOnSpecificPrerequisitesRegardingDevelopmentProjects'?: StringNode;
-  'g:PropertyPlantAndEquipmentGross'?: NumberWithUnitRef[];
-  'g:AdditionsToPropertyPlantAndEquipment'?: NumberWithUnitRef[];
-  'g:DisposalsOfPropertyPlantAndEquipment'?: NumberWithUnitRef[];
-  'g:AccumulatedRevaluationOfPropertyPlantAndEquipment'?: NumberWithUnitRef[];
-  'g:AccumulatedImpairmentLossesAndDepreciationOfPropertyPlantAndEquipment'?: NumberWithUnitRef[];
-  'g:InvestmentsGross'?: NumberWithUnitRef[];
-  'g:AccumulatedRevaluationsOfInvestments'?: NumberWithUnitRef[];
-  'g:ProfitLossRelatedToInvestments'?: NumberWithUnitRef[];
-  'g:LongtermInvestmentsAndReceivables'?: NumberWithUnitRef[];
-  'g:RelatedEntityName'?: StringNode;
-  'g:RelatedEntityRegisteredOffice'?: StringNode;
-  'g:ShareHeldByEntityOrConsolidatedEnterprisesInRelatedEntity'?: NumberWithUnitRef;
-  'g:DisclosureOfContingentLiabilities'?: StringNode;
-  'g:DisclosureOfMortgagesAndCollaterals'?: StringNode;
-  'h:InformationOnTypeOfSubmittedReport'?: StringNode;
-  'h:IdentificationNumberCvrOfSubmittingEnterprise'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:NameOfSubmittingEnterprise'?: StringNode;
-  'h:AddressOfSubmittingEnterpriseStreetAndNumber'?: StringNode;
-  'h:AddressOfSubmittingEnterprisePostcodeAndTown'?: StringNode;
-  'h:ReportingPeriodStartDate'?: StringNode;
-  'h:ReportingPeriodEndDate'?: StringNode;
-  'h:PrecedingReportingPeriodStartDate'?: StringNode;
-  'h:PredingReportingPeriodEndDate'?: StringNode;
-  'h:IdentificationNumberCvrOfReportingEntity'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:NameOfReportingEntity'?: StringNode;
-  'h:AddressOfReportingEntityStreetName'?: StringNode;
-  'h:AddressOfReportingEntityStreetBuildingIdentifier'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:AddressOfReportingEntityPostCodeIdentifier'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:AddressOfReportingEntityDistrictName'?: StringNode;
-  'h:AddressOfReportingEntityCountryIdentificationCode'?: StringNode;
-  'h:AddressOfReportingEntityCountry'?: StringNode;
-  'h:DateOfFoundationOfReportingEntity'?: StringNode;
-  'h:RegisteredOfficeOfReportingEntity'?: StringNode;
-  'h:NameOfFinancialInstitution'?: StringNode;
-  'd:IdentificationNumberCvrOfAuditFirm'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:AddressOfAuditorStreetName'?: StringNode;
-  'h:AddressOfAuditorStreetBuildingIdentifier'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:AddressOfAuditorPostCodeIdentifier'?: DIdentificationNumberCvrOfAuditFirm;
-  'h:AddressOfAuditorDistrictName'?: StringNode;
-  'h:AddressOfAuditorCountryIdentificationCode'?: StringNode;
-  'h:AddressOfAuditorCountry'?: StringNode;
-  'h:DateOfGeneralMeeting'?: StringNode;
-  'h:NameAndSurnameOfChairmanOfGeneralMeeting'?: StringNode;
-  'g:ClassOfReportingEntity'?: StringNode;
-  'g:SelectedElementsFromReportingClassC'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  'd:TypeOfAuditorAssistance': StringNode;
-  'h:ToolForPreparingTheXBRLInstanceDocument'?: StringNode;
-  'e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyTheCriminalCodeAndFiscalTaxAndSubsidyLegislationExtendedReview'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  'e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyTheCompaniesActOrEquivalentLegislationThatTheCompanyIsSubjectToExtendedReview'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  'e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  'e:ReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyOtherMattersExtendedReview'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  context: Context[];
-  unit: Unit[];
-  '@_xmlns': string;
-  '@_xmlns:c': string;
-  '@_xmlns:b': string;
-  '@_xmlns:f': string;
-  '@_xmlns:e': string;
-  '@_xmlns:d': string;
-  '@_xmlns:h'?: string;
-  '@_xmlns:g': string;
-  '@_xmlns:xlink': string;
-  '@_xmlns:xbrli': string;
-  '@_xmlns:iso4217': string;
-  '@_xmlns:xbrldi': string;
-  '@_xmlns:link': string;
-  '@_xmlns:xsi': string;
-  '@_xsi:schemaLocation': string;
-  'c:ConfirmationThatFinancialStatementsAreExemptedFromAuditing'?: StringNode;
-  'd:TitleOfMemberOfExecutiveBoard'?: StringNode;
-  'e:DescriptionOfPrimaryActivitiesOfEntity'?: StringNode;
-  'e:DescriptionOfDevelopmentInActivitiesAndFinancialAffairs'?: StringNode;
-  'f:GrossProfitLoss'?: NumberWithUnitRef[];
-  'f:IncomeFromInvestmentsInGroupEnterprises'?: NumberWithUnitRef[];
-  'f:OtherFinanceIncome'?: NumberWithUnitRef[];
-  'f:OtherFinanceExpenses'?: NumberWithUnitRef[];
-  'f:ProfitLossFromOrdinaryActivitiesBeforeTax'?: NumberWithUnitRef[];
-  'f:TaxExpense'?: NumberWithUnitRef[];
-  'f:ProfitLoss'?: NumberWithUnitRef[];
-  'f:LongtermInvestmentsInGroupEnterprises'?: NumberWithUnitRef[];
-  'f:LongtermInvestmentsAndReceivables'?: NumberWithUnitRef[];
-  'f:NoncurrentAssets'?: NumberWithUnitRef[];
-  'f:ShorttermReceivablesFromAssociates'?: NumberWithUnitRef[];
-  'f:ShorttermReceivablesFromOwnersAndManagement'?: NumberWithUnitRef[];
-  'f:ShorttermReceivables'?: NumberWithUnitRef[];
-  'f:CashAndCashEquivalents'?: NumberWithUnitRef[];
-  'f:CurrentAssets'?: NumberWithUnitRef[];
-  'f:Assets'?: NumberWithUnitRef[];
-  'f:ContributedCapital'?: NumberWithUnitRef[];
-  'f:ReserveForEntrepreneurialCompany'?: NumberWithUnitRef[];
-  'f:RetainedEarnings'?: NumberWithUnitRef[];
-  'f:Equity'?: NumberWithUnitRef[];
-  'f:ShorttermPayablesToGroupEnterprises'?: NumberWithUnitRef[];
-  'f:ShorttermLiabilitiesOtherThanProvisions'?: NumberWithUnitRef[];
-  'f:LiabilitiesOtherThanProvisions'?: NumberWithUnitRef[];
-  'f:LiabilitiesAndEquity'?: NumberWithUnitRef[];
-  'f:InvestmentsGross'?: NumberWithUnitRef[];
-  'f:AccumulatedRevaluationsOfInvestments'?: NumberWithUnitRef[];
-  'f:ProfitLossRelatedToInvestments'?: NumberWithUnitRef[];
-  'f:DisclosureOfInvestments'?: StringNode;
-  'f:RelatedEntityName'?: StringNode;
-  'f:RelatedEntityRegisteredOffice'?: StringNode;
-  'f:ShareHeldByEntityOrConsolidatedEnterprisesInRelatedEntity'?: NumberWithUnitRef;
-  'f:InterestRateRelatedToOutstandingDebtFromManagementCategory'?: NumberWithUnitRef[];
-  'g:InformationOnTypeOfSubmittedReport'?: StringNode;
-  'g:IdentificationNumberCvrOfSubmittingEnterprise'?: DIdentificationNumberCvrOfAuditFirm;
-  'g:NameOfSubmittingEnterprise'?: StringNode;
-  'g:AddressOfSubmittingEnterpriseStreetAndNumber'?: StringNode;
-  'g:AddressOfSubmittingEnterprisePostcodeAndTown'?: StringNode;
-  'g:ReportingPeriodStartDate'?: StringNode;
-  'g:ReportingPeriodEndDate'?: StringNode;
-  'g:PrecedingReportingPeriodStartDate'?: StringNode;
-  'g:PredingReportingPeriodEndDate'?: StringNode;
-  'g:IdentificationNumberCvrOfReportingEntity'?: DIdentificationNumberCvrOfAuditFirm;
-  'g:NameOfReportingEntity'?: StringNode;
-  'g:AddressOfReportingEntityStreetName'?: StringNode;
-  'g:AddressOfReportingEntityStreetBuildingIdentifier'?: DIdentificationNumberCvrOfAuditFirm;
-  'g:AddressOfReportingEntityPostCodeIdentifier'?: DIdentificationNumberCvrOfAuditFirm;
-  'g:AddressOfReportingEntityDistrictName'?: StringNode;
-  'g:AddressOfReportingEntityCountryIdentificationCode'?: StringNode;
-  'g:AddressOfReportingEntityCountry'?: StringNode;
-  'g:RegisteredOfficeOfReportingEntity'?: StringNode;
-  'g:DateOfGeneralMeeting'?: StringNode;
-  'g:NameAndSurnameOfChairmanOfGeneralMeeting'?: StringNode;
-  'f:ClassOfReportingEntity'?: StringNode;
-  'f:SelectedElementsFromReportingClassC'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  'f:InformationOnReportingClassOfEntity'?: StringNode;
-  'f:DescriptionOfGeneralMattersRelatedToRecognitionMeasurementAndChangesInAccountingPolicies'?: StringNode;
-  'f:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfFinanceIncomeAndExpenses'?: StringNode;
-  'f:DescriptionOfMethodsOfRecognitionAndMeasurementBasisForInvestmentsInSubsidiariesAndAssociates'?: StringNode;
-  'f:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfReceivables'?: StringNode;
-  'f:DescriptionOfMethodsOfDividends'?: StringNode;
-  'f:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfTaxPayablesAndDeferredTax'?: StringNode;
-  'f:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfLiabilitiesOtherThanProvisions'?: StringNode;
 }
 
 export interface StringNode {
@@ -263,31 +19,9 @@ export interface StringNode {
   '@_xml:lang'?: string;
 }
 
-export interface Context {
-  entity: Entity;
-  period: Period;
-  '@_id': string;
-  scenario?: Scenario;
-}
-
-export interface Entity {
-  identifier: Identifier;
-}
-
 export interface Identifier {
   '#text': number;
   '@_scheme': string;
-}
-
-export interface Period {
-  startDate?: string;
-  endDate?: string;
-  instant?: string;
-}
-
-export interface Scenario {
-  'xbrldi:typedMember'?: ScenarioXbrldiTypedMember;
-  'xbrldi:explicitMember'?: XbrldiExplicitMember;
 }
 
 export interface XbrldiExplicitMember {
@@ -305,11 +39,6 @@ export interface ScenarioXbrldiTypedMember {
 
 export interface DIdentificationNumberCvrOfAuditFirm {
   '#text': number;
-  '@_contextRef': string;
-}
-
-export interface EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview {
-  '#text': boolean;
   '@_contextRef': string;
 }
 
@@ -351,7 +80,7 @@ export interface XbrliXbrl {
   'cmn:NameOfAuditFirm'?: StringNode[] | StringNode;
   'cmn:TitleOfMemberOfSupervisoryBoard'?: StringNode;
   'cmn:TypeOfAuditorAssistance': StringNode;
-  'fsa:AccountingPoliciesAreUnchangedFromPreviousPeriod': Fsa;
+  'fsa:AccountingPoliciesAreUnchangedFromPreviousPeriod': BooleanWithRef;
   'fsa:Assets': NumberWithUnitRef[];
   'fsa:AverageNumberOfEmployees'?: NumberWithUnitRef[];
   'fsa:CashAndCashEquivalents': NumberWithUnitRef[];
@@ -398,7 +127,7 @@ export interface XbrliXbrl {
   'fsa:PurchaseOfTreasuryShares'?: NumberWithUnitRef[];
   'fsa:ReserveForDevelopmentExpenditure'?: NumberWithUnitRef[];
   'fsa:RetainedEarnings': NumberWithUnitRef[];
-  'fsa:SelectedElementsFromReportingClassC'?: Fsa;
+  'fsa:SelectedElementsFromReportingClassC'?: BooleanWithRef;
   'fsa:ShorttermDebtToBanks'?: NumberWithUnitRef[];
   'fsa:ShorttermDeferredIncome'?: NumberWithUnitRef[];
   'fsa:ShorttermLiabilitiesOtherThanProvisions': NumberWithUnitRef[];
@@ -561,8 +290,8 @@ export interface XbrliXbrl {
   '@_xmlns:msg'?: string;
   '@_xmlns:label'?: string;
   '@_xsi:schemaLocation'?: string;
-  'sob:TheReportingEntityAppliesTheExceptionConcerningOptingOutOfTheStatementByManagementEtc'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
-  'fsa:SelectedElementsFromReportingClassD'?: EReportingResponsibilitiesAccordingToTheDanishExecutiveOrderOnApprovedAuditorsReportsEspeciallyLegislationOnFinancialReportingIncludingAccountingAndStorageOfAccountingRecordsExtendedReview;
+  'sob:TheReportingEntityAppliesTheExceptionConcerningOptingOutOfTheStatementByManagementEtc'?: BooleanWithRef;
+  'fsa:SelectedElementsFromReportingClassD'?: BooleanWithRef;
   'gsd:AddressOfReportingEntityCountryIdentificationCode'?: StringNode;
   'mrv:DescriptionOfSignificantEventsOccurringAfterEndOfReportingPeriod'?: StringNode;
   'fsa:DescriptionOfMethodsOfRecognitionAndMeasurementBasisOfGrossProfitLoss'?: StringNode;
@@ -649,7 +378,7 @@ export interface GsdAddressOfAuditorPostCodeIdentifier {
   '@_xml:lang'?: string;
 }
 
-export interface Fsa {
+export interface BooleanWithRef {
   '#text': boolean;
   '@_contextRef': string;
   '@_xml:lang'?: string;


### PR DESCRIPTION
This commit adds a namespace cleanup step to the initial XML parsing
such that XBRL files with slightly different namespace names are
supported.

This change also helps simplify the types.