### PR TITLE
Use alternative EBITDA/EBIT calculation

### DIFF
--- a/__tests__/parse.test.ts
+++ b/__tests__/parse.test.ts
@@ -27,13 +27,15 @@ describe('parse', () => {
       depreciationAmortization: 264_924_000,
       otherFinancialIncome: 22_411_000,
       otherFinancialExpenses: 51_439_000,
-      calculatedEBIT: -22_878_000,
+      calculatedEBIT: 6_150_000,
       profitLossBeforeTax: -22_878_000,
       profitLoss: -2_8633_000,
       tax: 5_755_000,
       grossProfitLoss: undefined,
       grossResult: undefined,
     }));
+
+    expect(report.incomeStatement.calculatedEBIT).toEqual(report.incomeStatement.profitLossFromOperatingActivities);
 
     expect(report.balance).toEqual(expect.objectContaining<Balance>({
       date: '2020-12-31',
@@ -101,7 +103,7 @@ describe('parse', () => {
       profitLossFromOperatingActivities: 2_954_097,
       otherFinancialExpenses: 84_114,
       otherFinancialIncome: 10_338,
-      calculatedEBIT: 2_880_321,
+      calculatedEBIT: 2_954_097,
       profitLossBeforeTax: 2_880_321,
       tax: 645_297,
       profitLoss: 2_235_024,
@@ -111,6 +113,8 @@ describe('parse', () => {
       otherOperatingIncome: undefined,
       grossResult: undefined,
     }));
+
+    expect(report.incomeStatement.calculatedEBIT).toEqual(report.incomeStatement.profitLossFromOperatingActivities);
 
     expect(report.balance).toEqual(expect.objectContaining<Balance>({
       date: '2021-07-31',
@@ -177,7 +181,7 @@ describe('parse', () => {
       profitLossFromOperatingActivities: 799_118,
       otherFinancialExpenses: 55_911,
       otherFinancialIncome: 115_300,
-      calculatedEBIT: 858_507,
+      calculatedEBIT: 799_118,
       profitLossBeforeTax: 858_507,
       tax: 208_964,
       profitLoss: 649_543,
@@ -187,6 +191,8 @@ describe('parse', () => {
       otherOperatingIncome: undefined,
       grossResult: undefined,
     }));
+
+    expect(report.incomeStatement.calculatedEBIT).toEqual(report.incomeStatement.profitLossFromOperatingActivities);
 
     expect(report.balance).toEqual(expect.objectContaining<Balance>({
       date: '2020-12-31',

--- a/src/parsers/cvr.ts
+++ b/src/parsers/cvr.ts
@@ -118,25 +118,18 @@ function createIncomeStatement(doc: XbrliXbrl, periodId: string): IncomeStatemen
 }
 
 function calculateEBITDA(i: IncomeStatement): number {
-  // Some companies have revenue, some have grossProfitLoss. They are similar
-  // but not quite the same it seems.
-  // TODO: Need to investigate this more!
-  const startingPoint = i.revenue ? i.revenue : i.grossProfitLoss;
-  if (!startingPoint) {
-    return 0;
-  }
-  return startingPoint
-    + (i.otherOperatingIncome || 0)
-    - i.employeeExpenses
-    - (i.externalExpenses || 0)
-    - (i.otherOperatingExpenses || 0);
+  return i.profitLoss
+    + i.tax
+    + (i.depreciationAmortization || 0)
+    // It is assumed that financial expenses and income correspond to interest,
+    // but it is not fully clear from the taxonomy
+    + (i.otherFinancialExpenses || 0)
+    - (i.otherFinancialIncome || 0);
 }
 
 function calculateEBIT(i: IncomeStatement): number {
   return i.calculatedEBITDA
-    - (i.depreciationAmortization || 0)
-    - (i.otherFinancialExpenses || 0)
-    + (i.otherFinancialIncome || 0);
+    - (i.depreciationAmortization || 0);
 }
 
 function extractTax(doc: XbrliXbrl, periodId: string): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface IncomeStatement {
 
   /**
    * This is the result before financial posts, i.e. it (should be) EBITDA -
-   * depreciation.
+   * depreciation/amortization.
    * da: Driftsresultat/resultat før finansielle poster
    */
   profitLossFromOperatingActivities: number;


### PR DESCRIPTION
This commit changes the EBITDA and EBIT calculations such that they
correspond better to online formulas, where the norm is to calculate EBITDA
and EBIT "backwards", starting at the net profit (after taxes) and
adding back taxes, interest, etc.